### PR TITLE
Added image_reference_uuid parameter to image creation endpoint

### DIFF
--- a/src/main/scala/org/mbari/vars/annotation/api/v1/ImageV1Api.scala
+++ b/src/main/scala/org/mbari/vars/annotation/api/v1/ImageV1Api.scala
@@ -130,10 +130,11 @@ class ImageV1Api(controller: ImageController)(implicit val executor: ExecutionCo
       )
     }
 
-    val format      = params.get("format")
-    val width       = params.getAs[Int]("width_pixels")
-    val height      = params.getAs[Int]("height_pixels")
-    val description = params.get("description")
+    val format             = params.get("format")
+    val width              = params.getAs[Int]("width_pixels")
+    val height             = params.getAs[Int]("height_pixels")
+    val description        = params.get("description")
+    val imageReferenceUUID = params.getAs[UUID]("image_reference_uuid")
     controller
       .create(
         videoReferenceUUID,
@@ -144,7 +145,8 @@ class ImageV1Api(controller: ImageController)(implicit val executor: ExecutionCo
         format,
         width,
         height,
-        description
+        description,
+        imageReferenceUUID
       )
       .map(toJson)
   }

--- a/src/main/scala/org/mbari/vars/annotation/controllers/ImageController.scala
+++ b/src/main/scala/org/mbari/vars/annotation/controllers/ImageController.scala
@@ -74,7 +74,8 @@ class ImageController(daoFactory: BasicDAOFactory) {
       format: Option[String],
       width: Option[Int],
       height: Option[Int],
-      description: Option[String]
+      description: Option[String],
+      imageReferenceUUID: Option[UUID]
   )(implicit ec: ExecutionContext): Future[Image] = {
 
     val imDao = daoFactory.newImagedMomentDAO()
@@ -83,6 +84,7 @@ class ImageController(daoFactory: BasicDAOFactory) {
       val imagedMoment = ImagedMomentController
         .findOrCreateImagedMoment(imDao, videoReferenceUUID, timecode, recordedDate, elapsedTime)
       val imageReference = irDao.newPersistentObject(url, description, height, width, format)
+      imageReferenceUUID.foreach(uuid => imageReference.uuid = uuid)
       irDao.create(imageReference)
       imagedMoment.addImageReference(imageReference)
       imageReference


### PR DESCRIPTION
Followed the model of how an association UUID can be specified, see [AssociationV1Api.scala#L87](https://github.com/mbari-media-management/annosaurus/blob/master/src/main/scala/org/mbari/vars/annotation/api/v1/AssociationV1Api.scala#L87) and [AssociationController.scala#L68](https://github.com/mbari-media-management/annosaurus/blob/master/src/main/scala/org/mbari/vars/annotation/controllers/AssociationController.scala#L68).

Builds, but needs to be tested.